### PR TITLE
Optionally skip predefined roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.11.1
+
+- Key changes:
+  - Added an option to skip the file with predefined roles through setting `ACL_PATH` to an empty value. This might be useful in environments that fully rely on Assumed Roles (=autoconfiguration).
+
 ## 0.11.0
 
 - Key changes:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Docker images are published on [ghcr.io/weisdd/lfgw](https://github.com/weisdd/l
 |                      | `SET_PROXY_HEADERS`         | `false`       | Whether to set proxy headers (`X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`). |
 |                      |                             |               |                                                              |
 | **OIDC**             |                             |               |                                                              |
-|                      | `ACL_PATH`                  | `./acl.yaml`  | Path to a file with ACL definitions (OIDC role to namespace bindings). |
+|                      | `ACL_PATH`                  | `./acl.yaml`  | Path to a file with ACL definitions (OIDC role to namespace bindings). Skipped if `ACL_PATH` is empty (might be useful when autoconfiguration is enabled through `ASSUMED_ROLES=true`). |
 |                      | `OIDC_REALM_URL`            |               | OIDC Realm URL, e.g. `https://auth.microk8s.localhost/auth/realms/cicd` |
 |                      | `OIDC_CLIENT_ID`            |               | OIDC Client ID (1*)                                          |
 

--- a/cmd/lfgw/main.go
+++ b/cmd/lfgw/main.go
@@ -97,15 +97,25 @@ func main() {
 			Msg("Assumed roles mode is off")
 	}
 
-	app.ACLMap, err = app.loadACL()
-	if err != nil {
-		app.logger.Fatal().Caller().
-			Err(err).Msgf("Failed to load ACL")
-	}
+	if app.ACLPath != "" {
+		app.ACLMap, err = app.loadACL()
+		if err != nil {
+			app.logger.Fatal().Caller().
+				Err(err).Msgf("Failed to load ACL")
+		}
 
-	for role, acl := range app.ACLMap {
+		for role, acl := range app.ACLMap {
+			app.logger.Info().Caller().
+				Msgf("Loaded role definition for %s: %q (converted to %s)", role, acl.RawACL, acl.LabelFilter.AppendString(nil))
+		}
+	} else {
+		if !app.AssumedRoles {
+			app.logger.Fatal().Caller().
+				Msgf("The app cannot run without at least one source of configuration (Non-empty ACL_PATH and/or ASSUMED_ROLES set to true)")
+		}
+
 		app.logger.Info().Caller().
-			Msgf("Loaded role definition for %s: %q (converted to %s)", role, acl.RawACL, acl.LabelFilter.AppendString(nil))
+			Msgf("ACL_PATH is empty, thus predefined roles are not loaded")
 	}
 
 	app.logger.Info().Caller().


### PR DESCRIPTION
- Key changes:
  - Added an option to skip the file with predefined roles through setting `ACL_PATH` to an empty value. This might be useful in environments that fully rely on Assumed Roles (=autoconfiguration).