### PR TITLE
Support all HTTP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Key changes:
   - All HTTP methods are allowed now (previously, only POST/GET requests were supported due to technical reasons);
-  - `VictoriaMetrics/metricsql` bumped from 0.40.0 to 0.41.0.
+  - `VictoriaMetrics/metricsql` bumped from `0.40.0` to `0.41.0`.
 
 ## 0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.11.2
+
+- Key changes:
+  - Non-GET / -POST requests are now blocked only when safe mode is enabled.
+
 ## 0.11.1
 
 - Key changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.11.2
 
 - Key changes:
-  - Non-GET / -POST requests are now blocked only when safe mode is enabled.
+  - All HTTP methods are allowed now (previously, only POST/GET requests were supported due to technical reasons);
+  - `VictoriaMetrics/metricsql` bumped from 0.40.0 to 0.41.0.
 
 ## 0.11.1
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,6 +4,7 @@ tasks:
   default:
     - task: test
     - task: lint
+    - task: tidy
 
   test:
     cmds:
@@ -13,3 +14,7 @@ tasks:
   lint:
     cmds:
       - golangci-lint run
+
+  tidy:
+    cmds:
+      - go mod tidy

--- a/cmd/lfgw/helpers.go
+++ b/cmd/lfgw/helpers.go
@@ -92,6 +92,7 @@ func (app *application) isNotAPIRequest(path string) bool {
 // isUnsafePath returns true if the requested path targets a potentially dangerous endpoint (admin or remote write).
 func (app *application) isUnsafePath(path string) bool {
 	// TODO: move to regexp?
+	// TODO: more unsafe paths?
 	return strings.Contains(path, "/admin/tsdb") || strings.Contains(path, "/api/v1/write")
 }
 

--- a/cmd/lfgw/middleware.go
+++ b/cmd/lfgw/middleware.go
@@ -71,14 +71,11 @@ func (app *application) logMiddleware(next http.Handler) http.Handler {
 // safeModeMiddleware forbids access to some API endpoints if safe mode is enabled
 func (app *application) safeModeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if app.SafeMode {
-			// TODO: more unsafe paths?
-			if app.isUnsafePath(r.URL.Path) {
-				hlog.FromRequest(r).Error().Caller().
-					Msgf("Blocked a request to %s", r.URL.Path)
-				app.clientError(w, http.StatusForbidden)
-				return
-			}
+		if app.SafeMode && app.isUnsafePath(r.URL.Path) {
+			hlog.FromRequest(r).Error().Caller().
+				Msgf("Blocked a request to %s", r.URL.Path)
+			app.clientError(w, http.StatusForbidden)
+			return
 		}
 
 		next.ServeHTTP(w, r)
@@ -93,6 +90,7 @@ func (app *application) proxyHeadersMiddleware(next http.Handler) http.Handler {
 			r.Header.Set("X-Forwarded-Proto", r.URL.Scheme)
 			r.Header.Set("X-Forwarded-Host", r.Header.Get("Host"))
 		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/cmd/lfgw/middleware.go
+++ b/cmd/lfgw/middleware.go
@@ -41,7 +41,7 @@ func (app *application) logMiddleware(next http.Handler) http.Handler {
 				return
 			}
 
-			// Once r.ParseForm() is called, we need to update ContentLength, otherwise the request will fail
+			// Once r.ParseForm() is called, we need to update ContentLength, otherwise the request will fail. r.PostForm contains data for PATCH, POST, and PUT requests.
 			postForm := r.PostForm.Encode()
 			newBody := strings.NewReader(postForm)
 			r.ContentLength = newBody.Size()

--- a/cmd/lfgw/middleware_test.go
+++ b/cmd/lfgw/middleware_test.go
@@ -59,48 +59,6 @@ func TestSafeModeMiddleware(t *testing.T) {
 			safeMode: false,
 			want:     http.StatusOK,
 		},
-		{
-			name:     "GET (safe mode on)",
-			path:     "/",
-			method:   http.MethodGet,
-			safeMode: true,
-			want:     http.StatusOK,
-		},
-		{
-			name:     "GET (safe mode off)",
-			path:     "/",
-			method:   http.MethodGet,
-			safeMode: false,
-			want:     http.StatusOK,
-		},
-		{
-			name:     "POST (safe mode on)",
-			path:     "/",
-			method:   http.MethodPost,
-			safeMode: true,
-			want:     http.StatusOK,
-		},
-		{
-			name:     "POST (safe mode off)",
-			path:     "/",
-			method:   http.MethodPost,
-			safeMode: false,
-			want:     http.StatusOK,
-		},
-		{
-			name:     "PATCH (safe mode on)",
-			path:     "/",
-			method:   http.MethodPatch,
-			safeMode: true,
-			want:     http.StatusMethodNotAllowed,
-		},
-		{
-			name:     "PATCH (safe mode off)",
-			path:     "/",
-			method:   http.MethodPatch,
-			safeMode: false,
-			want:     http.StatusOK,
-		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/lfgw/routes.go
+++ b/cmd/lfgw/routes.go
@@ -11,11 +11,10 @@ func (app *application) routes() *mux.Router {
 	r.Use(app.nonProxiedEndpointsMiddleware)
 	r.Use(hlog.NewHandler(*app.logger))
 	r.Use(app.logMiddleware)
-	r.Use(app.prohibitedMethodsMiddleware)
-	r.Use(app.proxyHeadersMiddleware)
 	r.Use(app.oidcModeMiddleware)
-	// Better to keep it here to see user email in logs
-	r.Use(app.prohibitedPathsMiddleware)
+	// Better to keep it here to see user email in logs (for unsafe paths)
+	r.Use(app.safeModeMiddleware)
+	r.Use(app.proxyHeadersMiddleware)
 	r.Use(app.rewriteRequestMiddleware)
 	r.PathPrefix("/").Handler(app.proxy)
 	return r


### PR DESCRIPTION
- Key changes:
  - All HTTP methods are allowed now (previously, only POST/GET requests were supported due to technical reasons).