### PR TITLE
Suppress G112 for gosec (false positive), reformat code with gofumpt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 temp/
 acl.yaml
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example of `keycloak + grafana + lfgw` setup is described [here](docs/oidc.md).
 
 | Variable                    | Default Value | Description                                                  |
 | --------------------------- | ------------- | ------------------------------------------------------------ |
-| `UPSTREAM_URL`              |               | Prometheus URL, e.g. `http://prometheus.localhost`. |
+| `UPSTREAM_URL`              |               | Prometheus URL, e.g. `http://prometheus.localhost`.          |
 | `OIDC_REALM_URL`            |               | OIDC Realm URL, e.g. `https://keycloak.localhost/auth/realms/monitoring` |
 | `OIDC_CLIENT_ID`            |               | OIDC Client ID (1*)                                          |
 | `ACL_PATH`                  | `./acl.yaml`  | Path to a file with ACL definitions (OIDC role to namespace bindings). Skipped if `ACL_PATH` is empty (might be useful when autoconfiguration is enabled through `ASSUMED_ROLES=true`). |

--- a/cmd/lfgw/main.go
+++ b/cmd/lfgw/main.go
@@ -1,13 +1,12 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/urfave/cli/v2"
 	"github.com/weisdd/lfgw/internal/lfgw"
-
-	"fmt"
-	"os"
 )
 
 var (
@@ -153,7 +152,7 @@ func main() {
 			},
 			&cli.DurationFlag{
 				Name:     "read-timeout",
-				Usage:    "the maximum time the from when the connection is accepted to when the request body is fully read",
+				Usage:    "the maximum time from when the connection is accepted to when the request body is fully read",
 				EnvVars:  []string{"READ_TIMEOUT"},
 				Value:    10 * time.Second,
 				Required: false,

--- a/internal/lfgw/middleware.go
+++ b/internal/lfgw/middleware.go
@@ -21,10 +21,12 @@ type userClaims struct {
 	Email string   `json:"email"`
 }
 
-var requestsTotal = metrics.NewCounter("requests_total")
-var federateDuration = metrics.NewSummary(`request_duration_seconds{path="/federate"}`)
-var queryDuration = metrics.NewSummary(`request_duration_seconds{path="/api/v1/query"}`)
-var queryRangeDuration = metrics.NewSummary(`request_duration_seconds{path="/api/v1/query_range"}`)
+var (
+	requestsTotal      = metrics.NewCounter("requests_total")
+	federateDuration   = metrics.NewSummary(`request_duration_seconds{path="/federate"}`)
+	queryDuration      = metrics.NewSummary(`request_duration_seconds{path="/api/v1/query"}`)
+	queryRangeDuration = metrics.NewSummary(`request_duration_seconds{path="/api/v1/query_range"}`)
+)
 
 // nonProxiedEndpointsMiddleware is a workaround to support healthz and metrics endpoints while forwarding everything else to an upstream.
 func (app *application) nonProxiedEndpointsMiddleware(next http.Handler) http.Handler {
@@ -95,7 +97,6 @@ func (app *application) logAndMetricsMiddleware(next http.Handler) http.Handler 
 			case "/api/v1/query_range":
 				queryRangeDuration.Update(d)
 			}
-
 		})(next)
 
 		next.ServeHTTP(w, r)

--- a/internal/lfgw/middleware_test.go
+++ b/internal/lfgw/middleware_test.go
@@ -237,7 +237,6 @@ func Test_proxyHeadersMiddleware(t *testing.T) {
 
 		defer rs.Body.Close()
 	})
-
 }
 
 func Test_oidcMiddleware(t *testing.T) {
@@ -756,7 +755,6 @@ func oidcGenerateToken(t *testing.T, c jwt.Claims) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, c)
 	token.Header["kid"] = "Po6hNo0dWOkmViTGxtw3ZkESATbmJcy8ntWxlKSAsW4"
 	rawToken, err := token.SignedString(privateKey)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lfgw/server.go
+++ b/internal/lfgw/server.go
@@ -25,6 +25,7 @@ func (app *application) serve() error {
 	app.proxy.FlushInterval = time.Millisecond * 200
 
 	// TODO: somehow pass more context to ErrorLog
+	//#nosec G112 -- false positive, may be removed after gosec v2.12.0+ is released
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", app.Port),
 		ErrorLog:     app.errorLog,

--- a/internal/querymodifier/acl.go
+++ b/internal/querymodifier/acl.go
@@ -20,7 +20,7 @@ type ACL struct {
 
 // NewACL returns an ACL based on a rule definition (non-regexp for one namespace, regexp - for many). .RawACL in the resulting value will contain a normalized value (anchors stripped, implicit admin will have only .*).
 func NewACL(rawACL string) (ACL, error) {
-	var lf = metricsql.LabelFilter{
+	lf := metricsql.LabelFilter{
 		Label:      "namespace",
 		IsNegative: false,
 		IsRegexp:   false,

--- a/internal/querymodifier/qm_test.go
+++ b/internal/querymodifier/qm_test.go
@@ -879,7 +879,6 @@ func Test_appendOrMergeRegexpLF(t *testing.T) {
 		got := appendOrMergeRegexpLF(filters, newFilter)
 		assert.Equal(t, want, got)
 	})
-
 }
 
 func Test_replaceLFByName(t *testing.T) {
@@ -934,7 +933,6 @@ func Test_replaceLFByName(t *testing.T) {
 		}
 		got := replaceLFByName(filters, newFilter)
 		assert.Equal(t, want, got)
-
 	})
 
 	t.Run("many matching labels", func(t *testing.T) {


### PR DESCRIPTION
- Suppress G112 (false positive);
- Reformat code with gofumpt;
- Tiny fix in flag description.