### PR TITLE
fix: revive unused parameter in lshortfile

### DIFF
--- a/internal/lfgw/logging.go
+++ b/internal/lfgw/logging.go
@@ -52,7 +52,7 @@ func (app *application) configureLogging() {
 }
 
 // lshortfile implements Lshortfile equivalent for zerolog's CallerMarshalFunc.
-func (app *application) lshortfile(pc uintptr, file string, line int) string {
+func (app *application) lshortfile(_ uintptr, file string, line int) string {
 	// Copied from the standard library: https://cs.opensource.google/go/go/+/refs/tags/go1.17.8:src/log/log.go;drc=926994fd7cf65b2703552686965fb05569699897;l=134
 	short := file
 	for i := len(file) - 1; i > 0; i-- {


### PR DESCRIPTION
- Fix:
  - Unused parameter in lshortfile:

```
internal/lfgw/logging.go:55:36: unused-parameter: parameter 'pc' seems to be unused, consider removing or renaming it as _ (revive)
func (app *application) lshortfile(pc uintptr, file string, line int) string {
                                   ^
```